### PR TITLE
Make the lock narrower

### DIFF
--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -680,7 +680,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                             )
                         )
                         .order_by(self.t_jobs.c.created_at)
-                        .with_for_update(skip_locked=True)
+                        .with_for_update(skip_locked=True, of=self.t_jobs)
                         .limit(limit)
                     )
 


### PR DESCRIPTION
We only need to lock the `jobs` table, not the `tasks` table.